### PR TITLE
Added support for multiple metrics per StatsD datagram

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statsd-filter-proxy-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["askldjd"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -101,5 +101,4 @@ The latency number should not be taken in absolute form because it doesn not acc
 CPU = Intel i7-8700K (12) @ 4.700GHz
 
 ## Limitations / Known Issues
-- statsd-filter-proxy-rs does not support multiple StatsD message per UDP datagram. 
 - StatsD datagram are capped at 8192 bytes. This can be only be adjusted in code at the moment.


### PR DESCRIPTION
StatsD protocol allows multiple metrics in a single datagram, as long as they are separated by `\n`. This is known as "buffering" in [Datadog dogstatsd](https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#enable-buffering-on-your-client). Filtering logic now supports this by tokenizing the string up front, and filter out each metric independently.